### PR TITLE
fix: removed try_name and try_symbol from index.js

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,9 +101,6 @@ function registerTransfer(
     token.URI = callResult.value;
   }
 
-  let nameResult = contract.try_name();
-  let symbolResult = contract.try_symbol();
-
   token.save();
   ev.save();
 }


### PR DESCRIPTION
These variables are not being used in the source code, and caused problems when i tried to deploy the graphs.